### PR TITLE
Changes database.yml production url

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -85,3 +85,5 @@ production:
   database: hello-block_production
   username: hello-block
   password: <%= ENV['HELLO-BLOCK_DATABASE_PASSWORD'] %>
+  production:
+  url: <%= ENV.fetch('DATABASE_URL', '').sub(/^postgres/, "postgis") %>


### PR DESCRIPTION
When running db:migrate on heroku, gis columns had failures. [Per documentation](https://devcenter.heroku.com/articles/rails-database-connection-behavior), if I change the url, everything should be ok. 

 *What changed?*: URL value in production section of database.yml
 *Passing RSPEC?*: Unchanged. 
